### PR TITLE
Add Vault contract

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -10,12 +10,20 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 interface StakeDAOVault is IERC20 {
     function deposit(uint256 _amount) external;
+
+    function withdraw(uint256 _amount) external;
 }
 
-interface CurveDepositZap {
+interface Curve3Pool {
     function add_liquidity(uint256[3] calldata amounts, uint256 min_mint_amount)
         external
         returns (uint256);
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        int128 i,
+        uint256 min_amount
+    ) external;
 }
 
 contract Vault is Ownable, ERC20 {
@@ -24,19 +32,19 @@ contract Vault is Ownable, ERC20 {
 
     IERC20 public dai;
     IERC20 public threeCrv;
-    CurveDepositZap public curveDepositZap;
+    Curve3Pool public curve3Pool;
     StakeDAOVault public stakeDAOvault;
 
     constructor(
         address _stakeDAOvault,
         address _dai,
         address _threeCrv,
-        address _curveDepositZap
+        address _curve3Pool
     ) ERC20("Commitment Contract Staking Vault", "cc-sd3Crv") {
         stakeDAOvault = StakeDAOVault(_stakeDAOvault);
         dai = IERC20(_dai);
         threeCrv = IERC20(_threeCrv);
-        curveDepositZap = CurveDepositZap(_curveDepositZap);
+        curve3Pool = Curve3Pool(_curve3Pool);
     }
 
     function deposit(address depositor, uint256 amount)
@@ -48,11 +56,8 @@ contract Vault is Ownable, ERC20 {
         dai.safeTransferFrom(msg.sender, address(this), amount);
 
         // Deposit DAI in Curve 3Pool
-        dai.safeIncreaseAllowance(address(curveDepositZap), amount);
-        uint256 threeCrvAmount = curveDepositZap.add_liquidity(
-            [amount, 0, 0],
-            0
-        );
+        dai.safeIncreaseAllowance(address(curve3Pool), amount);
+        uint256 threeCrvAmount = curve3Pool.add_liquidity([amount, 0, 0], 0);
 
         // Deposit 3Crv LP token in StakeDAO vault
         threeCrv.safeIncreaseAllowance(address(stakeDAOvault), threeCrvAmount);
@@ -64,6 +69,30 @@ contract Vault is Ownable, ERC20 {
         // Mint Vault shares equal to StakeDAO shares
         _mint(depositor, shares);
         return shares;
+    }
+
+    function withdraw(address shareholder, uint256 shares)
+        public
+        onlyOwner
+        returns (uint256)
+    {
+        _burn(shareholder, shares);
+
+        uint256 threeCrvBalanceBefore = threeCrv.balanceOf(address(this));
+        stakeDAOvault.withdraw(shares);
+        uint256 threeCrvBalanceAfter = threeCrv.balanceOf(address(this));
+        uint256 threeCrvAmount = threeCrvBalanceAfter.sub(
+            threeCrvBalanceBefore
+        );
+
+        threeCrv.safeIncreaseAllowance(address(curve3Pool), threeCrvAmount);
+        uint256 daiBalanceBefore = dai.balanceOf(address(this));
+        curve3Pool.remove_liquidity_one_coin(threeCrvAmount, 0, 0);
+        uint256 daiBalanceAfter = dai.balanceOf(address(this));
+        uint256 daiAmount = daiBalanceAfter.sub(daiBalanceBefore);
+
+        dai.transfer(shareholder, daiAmount);
+        return daiAmount;
     }
 
     function transfer(address recipient, uint256 amount)

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -16,8 +16,7 @@ interface StakeDAOVault is IERC20 {
 
 interface Curve3Pool {
     function add_liquidity(uint256[3] calldata amounts, uint256 min_mint_amount)
-        external
-        returns (uint256);
+        external;
 
     function remove_liquidity_one_coin(
         uint256 _token_amount,
@@ -57,7 +56,12 @@ contract Vault is Ownable, ERC20 {
 
         // Deposit DAI in Curve 3Pool
         dai.safeIncreaseAllowance(address(curve3Pool), amount);
-        uint256 threeCrvAmount = curve3Pool.add_liquidity([amount, 0, 0], 0);
+        uint256 threeCrvBalanceBefore = threeCrv.balanceOf(address(this));
+        curve3Pool.add_liquidity([amount, 0, 0], 0);
+        uint256 threeCrvBalanceAfter = threeCrv.balanceOf(address(this));
+        uint256 threeCrvAmount = threeCrvBalanceAfter.sub(
+            threeCrvBalanceBefore
+        );
 
         // Deposit 3Crv LP token in StakeDAO vault
         threeCrv.safeIncreaseAllowance(address(stakeDAOvault), threeCrvAmount);

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 interface StakeDAOVault is IERC20 {
     function deposit(uint256 _amount) external;
@@ -17,7 +18,7 @@ interface CurveDepositZap {
         returns (uint256);
 }
 
-contract Vault is ERC20 {
+contract Vault is Ownable, ERC20 {
     using SafeERC20 for IERC20;
     using SafeMath for uint256;
 
@@ -31,33 +32,54 @@ contract Vault is ERC20 {
         address _dai,
         address _threeCrv,
         address _curveDepositZap
-    ) ERC20("Commitment Contract Vault", "ccDAI") {
+    ) ERC20("Commitment Contract Staking Vault", "cc-sd3Crv") {
         stakeDAOvault = StakeDAOVault(_stakeDAOvault);
         dai = IERC20(_dai);
         threeCrv = IERC20(_threeCrv);
         curveDepositZap = CurveDepositZap(_curveDepositZap);
     }
 
-    function deposit(uint256 amount) public returns (uint256) {
+    function deposit(address depositor, uint256 amount)
+        public
+        onlyOwner
+        returns (uint256)
+    {
         // Transfer in DAI from sender
         dai.safeTransferFrom(msg.sender, address(this), amount);
 
         // Deposit DAI in Curve 3Pool
-        dai.approve(address(curveDepositZap), amount);
+        dai.safeIncreaseAllowance(address(curveDepositZap), amount);
         uint256 threeCrvAmount = curveDepositZap.add_liquidity(
             [amount, 0, 0],
             0
         );
 
         // Deposit 3Crv LP token in StakeDAO vault
-        threeCrv.approve(address(stakeDAOvault), threeCrvAmount);
+        threeCrv.safeIncreaseAllowance(address(stakeDAOvault), threeCrvAmount);
         uint256 shareBalanceBefore = stakeDAOvault.balanceOf(address(this));
         stakeDAOvault.deposit(threeCrvAmount);
         uint256 shareBalanceAfter = stakeDAOvault.balanceOf(address(this));
         uint256 shares = shareBalanceAfter.sub(shareBalanceBefore);
 
         // Mint Vault shares equal to StakeDAO shares
-        _mint(msg.sender, shares);
+        _mint(depositor, shares);
         return shares;
+    }
+
+    function transfer(address recipient, uint256 amount)
+        public
+        override
+        returns (bool)
+    {
+        revert("Token is nontransferrable");
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public override returns (bool) {
+        require(recipient == address(this), "Unauthorized");
+        return super.transferFrom(sender, recipient, amount);
     }
 }

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+interface StakeDAOVault is IERC20 {
+    function deposit(uint256 _amount) external;
+}
+
+interface CurveDepositZap {
+    function add_liquidity(uint256[3] calldata amounts, uint256 min_mint_amount)
+        external
+        returns (uint256);
+}
+
+contract Vault is ERC20 {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+
+    IERC20 public dai;
+    IERC20 public threeCrv;
+    CurveDepositZap public curveDepositZap;
+    StakeDAOVault public stakeDAOvault;
+
+    constructor(
+        address _stakeDAOvault,
+        address _dai,
+        address _threeCrv,
+        address _curveDepositZap
+    ) ERC20("Commitment Contract Vault", "ccDAI") {
+        stakeDAOvault = StakeDAOVault(_stakeDAOvault);
+        dai = IERC20(_dai);
+        threeCrv = IERC20(_threeCrv);
+        curveDepositZap = CurveDepositZap(_curveDepositZap);
+    }
+
+    function deposit(uint256 amount) public returns (uint256) {
+        // Transfer in DAI from sender
+        dai.safeTransferFrom(msg.sender, address(this), amount);
+
+        // Deposit DAI in Curve 3Pool
+        dai.approve(address(curveDepositZap), amount);
+        uint256 threeCrvAmount = curveDepositZap.add_liquidity(
+            [amount, 0, 0],
+            0
+        );
+
+        // Deposit 3Crv LP token in StakeDAO vault
+        threeCrv.approve(address(stakeDAOvault), threeCrvAmount);
+        uint256 shareBalanceBefore = stakeDAOvault.balanceOf(address(this));
+        stakeDAOvault.deposit(threeCrvAmount);
+        uint256 shareBalanceAfter = stakeDAOvault.balanceOf(address(this));
+        uint256 shares = shareBalanceAfter.sub(shareBalanceBefore);
+
+        // Mint Vault shares equal to StakeDAO shares
+        _mint(msg.sender, shares);
+        return shares;
+    }
+}

--- a/contracts/mocks/MockCurve3Pool.sol
+++ b/contracts/mocks/MockCurve3Pool.sol
@@ -24,19 +24,17 @@ contract MockCurve3Pool {
 
     function add_liquidity(uint256[3] calldata amounts, uint256 min_mint_amount)
         external
-        returns (uint256)
     {
         dai.safeTransferFrom(msg.sender, address(this), amounts[0]);
         uint256 lpTokens = amounts[0].mul(1e18).div(virtualPrice);
         threeCrv.mint(msg.sender, lpTokens);
-        return lpTokens;
     }
 
     function remove_liquidity_one_coin(
         uint256 _token_amount,
         int128 i,
         uint256 min_amount
-    ) external returns (uint256) {
+    ) external {
         threeCrv.safeTransferFrom(msg.sender, address(this), _token_amount);
         uint256 daiAmount = virtualPrice.mul(_token_amount).div(1e18);
         uint256 slippage = daiAmount.mul(slippageBps).div(BPS_DENOMINATOR);

--- a/contracts/mocks/MockCurve3Pool.sol
+++ b/contracts/mocks/MockCurve3Pool.sol
@@ -6,13 +6,16 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./MockERC20.sol";
 
-contract MockCurveDepositZap {
+contract MockCurve3Pool {
     using SafeERC20 for MockERC20;
     using SafeMath for uint256;
 
     MockERC20 dai;
     MockERC20 threeCrv;
     uint256 virtualPrice = 1.0125 ether;
+    uint256 slippageBps = 10;
+
+    uint256 BPS_DENOMINATOR = 10000;
 
     constructor(address _dai, address _threeCrv) {
         dai = MockERC20(_dai);
@@ -27,5 +30,17 @@ contract MockCurveDepositZap {
         uint256 lpTokens = amounts[0].mul(1e18).div(virtualPrice);
         threeCrv.mint(msg.sender, lpTokens);
         return lpTokens;
+    }
+
+    function remove_liquidity_one_coin(
+        uint256 _token_amount,
+        int128 i,
+        uint256 min_amount
+    ) external returns (uint256) {
+        threeCrv.safeTransferFrom(msg.sender, address(this), _token_amount);
+        uint256 daiAmount = virtualPrice.mul(_token_amount).div(1e18);
+        uint256 slippage = daiAmount.mul(slippageBps).div(BPS_DENOMINATOR);
+        uint256 transferOut = daiAmount.sub(slippage);
+        dai.mint(msg.sender, transferOut);
     }
 }

--- a/contracts/mocks/MockCurveDepositZap.sol
+++ b/contracts/mocks/MockCurveDepositZap.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "./MockERC20.sol";
+
+contract MockCurveDepositZap {
+    using SafeERC20 for MockERC20;
+    using SafeMath for uint256;
+
+    MockERC20 dai;
+    MockERC20 threeCrv;
+    uint256 virtualPrice = 1.0125 ether;
+
+    constructor(address _dai, address _threeCrv) {
+        dai = MockERC20(_dai);
+        threeCrv = MockERC20(_threeCrv);
+    }
+
+    function add_liquidity(uint256[3] calldata amounts, uint256 min_mint_amount)
+        external
+        returns (uint256)
+    {
+        dai.safeTransferFrom(msg.sender, address(this), amounts[0]);
+        uint256 lpTokens = amounts[0].mul(1e18).div(virtualPrice);
+        threeCrv.mint(msg.sender, lpTokens);
+        return lpTokens;
+    }
+}

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -4,8 +4,10 @@ pragma solidity ^0.7.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-contract MockDai is ERC20 {
-    constructor() ERC20("MockDai", "DAI") {}
+contract MockERC20 is ERC20 {
+    constructor(string memory _name, string memory _symbol)
+        ERC20(_name, _symbol)
+    {}
 
     function mint(address _recipient, uint256 _amount) public {
         _mint(_recipient, _amount);

--- a/contracts/mocks/MockStakeDAOVault.sol
+++ b/contracts/mocks/MockStakeDAOVault.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+contract MockStakeDAOVault is ERC20 {
+    using SafeERC20 for IERC20;
+    using Address for address;
+    using SafeMath for uint256;
+
+    IERC20 public token;
+
+    constructor(address _token) ERC20("Mock StakeDAO USD Vault", "sd3Crv") {
+        token = IERC20(_token);
+    }
+
+    function balance() public view returns (uint256) {
+        return token.balanceOf(address(this));
+    }
+
+    function deposit(uint256 _amount) public {
+        uint256 _pool = balance();
+        uint256 _before = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), _amount);
+        uint256 _after = token.balanceOf(address(this));
+        _amount = _after.sub(_before); // Additional check for deflationary tokens
+        uint256 shares = 0;
+        if (totalSupply() == 0) {
+            shares = _amount;
+        } else {
+            shares = (_amount.mul(totalSupply())).div(_pool);
+        }
+        _mint(msg.sender, shares);
+    }
+
+    function withdraw(uint256 _shares) public {
+        uint256 r = (balance().mul(_shares)).div(totalSupply());
+        _burn(msg.sender, _shares);
+        token.safeTransfer(msg.sender, r);
+    }
+
+    function getPricePerFullShare() public view returns (uint256) {
+        return balance().mul(1e18).div(totalSupply());
+    }
+}

--- a/test/GoalManager.test.ts
+++ b/test/GoalManager.test.ts
@@ -13,8 +13,8 @@ describe("GoalManager", function () {
   beforeEach(async function () {
     [goalSetter] = await ethers.getSigners();
 
-    const MockDai = await ethers.getContractFactory("MockDai");
-    mockDai = await MockDai.deploy();
+    const MockDai = await ethers.getContractFactory("MockERC20");
+    mockDai = await MockDai.deploy("Mock Dai", "DAI");
 
     const GoalManager = await ethers.getContractFactory("GoalManager");
     goalManager = await GoalManager.deploy(mockDai.address);

--- a/test/Vault.test.ts
+++ b/test/Vault.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai";
+import { waffle, ethers } from "hardhat";
+import { parseEther } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+
+describe("Vault", function () {
+  let depositor,
+    mockDai,
+    mock3crv,
+    mockCurveDepositZap,
+    mockStakeDAOvault,
+    vault;
+
+  beforeEach(async function () {
+    [depositor] = await ethers.getSigners();
+
+    const MockDai = await ethers.getContractFactory("MockERC20");
+    mockDai = await MockDai.deploy("Mock Dai", "DAI");
+
+    const Mock3Crv = await ethers.getContractFactory("MockERC20");
+    mock3crv = await Mock3Crv.deploy("Mock 3Crv", "3Crv");
+
+    const MockCurveDepositZap = await ethers.getContractFactory(
+      "MockCurveDepositZap"
+    );
+    mockCurveDepositZap = await MockCurveDepositZap.deploy(
+      mockDai.address,
+      mock3crv.address
+    );
+
+    const MockStakeDAOVault = await ethers.getContractFactory(
+      "MockStakeDAOVault"
+    );
+    mockStakeDAOvault = await MockStakeDAOVault.deploy(mock3crv.address);
+
+    const Vault = await ethers.getContractFactory("Vault");
+    vault = await Vault.deploy(
+      mockStakeDAOvault.address,
+      mockDai.address,
+      mock3crv.address,
+      mockCurveDepositZap.address
+    );
+  });
+
+  describe("Contract setup", async function () {
+    it("Has a StakeDAO vault address", async function () {
+      expect(await vault.stakeDAOvault()).to.equal(mockStakeDAOvault.address);
+    });
+
+    it("Has a DAI address", async function () {
+      expect(await vault.dai()).to.equal(mockDai.address);
+    });
+  });
+
+  describe("Deposits", async function () {
+    it("Accepts DAI deposits, returns vault shares", async function () {
+      let deposit = parseEther("2500");
+      await mockDai.mint(depositor.address, deposit);
+      await mockDai.connect(depositor).approve(vault.address, deposit);
+      await vault.connect(depositor).deposit(deposit);
+      expect(await vault.balanceOf(depositor.address)).to.equal(
+        parseEther("2469.135802469135802469")
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Add `Vault` contract. This will be responsible for depositing user stakes in a yield generating protocol and keeping track of each user's share of the pooled assets.
- Add mocks for the many contracts the `Vault` needs to interact with. We want to deposit the user's stake in the [StakeDAO](https://stakedao.org/) passive USD strategy pool, but to do so, we need to make a few token transfers and interact with a few contracts:
  - Our end users make deposits in [Dai](https://makerdao.com/en/), an ERC20 stablecoin.
  - We deposit DAI in the [Curve Finance](https://curve.fi/) 3pool and get back 3Crv, the 3pool LP token. Curve is a decentralized exchange that is optimized for trading stablecoins. When you deposit stablecoins into a Curve pool, you get back a liquidity provider token ("LP token") representing your share of liquidity in the pool. Curve charges a fee for every trade, and LP token holders accrue these fees over time. There are many different pools on Curve, but we are depositing to the "3pool," which is composed of the three most popular stablecoins: Dai, USDC, and Tether. The LP token we get back is called "3Crv" (pronounced "three-curve").
  - We deposit our 3Crv tokens in the StakeDAO passive USD strategy pool and get back a third token called sd3Crv, which represents our share of contributions to the StakeDAO pool! 
  - We need mocks for all of these interactions: Dai, 3Crv, the StakeDAO pool, and the Curve "deposit zap," which is the contract used to add Dai to the 3pool.